### PR TITLE
Add `normalized` property to some accessors

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1370,7 +1370,17 @@ export class GLTFExporter {
             } else {
                 const bufferViewIndex = state.getVertexBufferView(vertexBuffer._buffer)!;
                 const byteOffset = vertexBuffer.byteOffset + start * vertexBuffer.byteStride;
-                this._accessors.push(createAccessor(bufferViewIndex, getAccessorType(kind, state.hasVertexColorAlpha(vertexBuffer)), vertexBuffer.type, count, byteOffset, minMax));
+                this._accessors.push(
+                    createAccessor(
+                        bufferViewIndex,
+                        getAccessorType(kind, state.hasVertexColorAlpha(vertexBuffer)),
+                        vertexBuffer.type,
+                        count,
+                        byteOffset,
+                        minMax,
+                        vertexBuffer.normalized // TODO: Find other places where this is needed.
+                    )
+                );
                 accessorIndex = this._accessors.length - 1;
                 state.setVertexAccessor(vertexBuffer, start, count, accessorIndex);
                 primitive.attributes[getAttributeType(kind)] = accessorIndex;

--- a/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
@@ -50,6 +50,7 @@ export function createBufferView(bufferIndex: number, byteOffset: number, byteLe
  * @param count The number of attributes referenced by this accessor
  * @param byteOffset The offset relative to the start of the bufferView in bytes
  * @param minMax Minimum and maximum value of each component in this attribute
+ * @param normalized Specifies whether integer data values are normalized before usage
  * @returns accessor for glTF
  */
 export function createAccessor(
@@ -58,13 +59,18 @@ export function createAccessor(
     componentType: AccessorComponentType,
     count: number,
     byteOffset: Nullable<number>,
-    minMax: Nullable<{ min: number[]; max: number[] }> = null
+    minMax: Nullable<{ min: number[]; max: number[] }> = null,
+    normalized?: boolean
 ): IAccessor {
     const accessor: IAccessor = { bufferView: bufferViewIndex, componentType: componentType, count: count, type: type };
 
     if (minMax != null) {
         accessor.min = minMax.min;
         accessor.max = minMax.max;
+    }
+
+    if (normalized) {
+        accessor.normalized = normalized;
     }
 
     if (byteOffset != null) {


### PR DESCRIPTION
While testing the playground from https://forum.babylonjs.com/t/how-to-get-instances-exported-when-instantiating-hierarchy-from-assetcontainer/41007?u=arraybuffer , I noticed we regressed in our exporter. Our roundtrip turned models white.

The GLB imported in the playground had vertex color accessors using UNSIGNED_SHORT, normalized = true.
Our OG exporter would turn this into a FLOAT accessor, normalized = undefined.
Our new exporter preserves it as an UNSIGNED_SHORT, but was missing normalized = true.

This PR assigns `normalized` to most* vertex accessors needing it via `createAccessor()`

\* There may be other places where we'll need to assign `normalized`, but I don't know enough about these places and the type conversions going on in them to feel comfortable doing it yet.